### PR TITLE
Add rule to ignore configuration files of JPA Buddy plugin in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 ### Querydsl
 /src/main/generated
 
+### JPA Buddy
+.jpb/
+
 ### Intellij+all ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # project-board
 
-The bulletin board project will use Java and Spring.
+게시판 기능을 구현한 서비스입니다. 스프링 부트와 관련 기술을 사용해서 만들었습니다.
+
+### 개발 환경
+
+Intellij IDEA Ultimate 2023.03.06
+Java open jdk 22
+Gradle 8.7
+Spring Boot 3.2.4
+
+### 기술 스택
+
+* Spring Boot Actuator
+* Spring Web
+* Spring Data JPA
+* Rest Repositories
+* Rest Repositories HAL Explorer
+* Thymeleaf
+* Spring Security
+* H2 Database
+* MySQL Driver
+* Lombok
+* Spring Boot DevTools
+* Spring Configuration Processor
+


### PR DESCRIPTION
When changing JPA Buddy settings in IntelliJ preferences, the JPA Buddy plugin saves the configuration to a separate hidden directory as files. Added to '.gitignore' for handling.