### PR TITLE
Remove the Serializable interface from DTOs

### DIFF
--- a/src/main/java/com/laphayen/projectboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/laphayen/projectboard/dto/response/ArticleCommentResponse.java
@@ -11,7 +11,7 @@ public record ArticleCommentResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleCommentResponse(id, content, createdAt, email, nickname);

--- a/src/main/java/com/laphayen/projectboard/dto/response/ArticleResponse.java
+++ b/src/main/java/com/laphayen/projectboard/dto/response/ArticleResponse.java
@@ -13,7 +13,7 @@ public record ArticleResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);

--- a/src/main/java/com/laphayen/projectboard/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/laphayen/projectboard/dto/response/ArticleWithCommentsResponse.java
@@ -18,7 +18,7 @@ public record ArticleWithCommentsResponse(
         String email,
         String nickname,
         Set<ArticleCommentResponse> articleCommentsResponse
-) implements Serializable {
+) {
 
     public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
         return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);


### PR DESCRIPTION
Remove the section where implements Serializable is automatically inserted into DTOs using JPA Buddy.
Jackson serialization is used in this project.

This closes #38 