### PR TITLE
Modify the equal() method in the entity

### DIFF
--- a/src/main/java/com/laphayen/projectboard/domain/Article.java
+++ b/src/main/java/com/laphayen/projectboard/domain/Article.java
@@ -54,8 +54,8 @@ public class Article extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        if (!(o instanceof Article that)) return false;
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/laphayen/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/laphayen/projectboard/domain/ArticleComment.java
@@ -41,7 +41,7 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return id != null && id.equals(that.getId());
     }
 
     @Override


### PR DESCRIPTION
When accessed directly, before and after becoming a proxy, there may be differences in instances that prevent equals and hashCode from correctly referencing each field.

This closes #50 