### PR TITLE
Thymeleaf CSS not applied due to Spring Security's SecurityConfig application

### DIFF
--- a/src/main/java/com/laphayen/projectboard/config/SecurityConfig.java
+++ b/src/main/java/com/laphayen/projectboard/config/SecurityConfig.java
@@ -24,10 +24,11 @@ public class SecurityConfig {
                .authorizeHttpRequests(auth -> auth
                        .requestMatchers(String.valueOf(PathRequest.toStaticResources().atCommonLocations())).permitAll()
                        .requestMatchers(
-                                HttpMethod.GET,
-                                "/",
-                                "/articles",
-                                "/articles/search-hashtag"
+                               HttpMethod.GET,
+                               "/",
+                               "/articles",
+                               "/articles/search-hashtag",
+                               "/css/**","/scripts/**","/plugin/**","/fonts/**"
                        ).permitAll()
                        .anyRequest().authenticated()
                )


### PR DESCRIPTION
Allowing Access to Static Files with Spring Security. 
When a request is made to the server, Spring Security performs authorization checks to determine if the resource is accessible.
Since it also checks static files, permissions for these files need to be allowed.