### PR TITLE
#69 - Apply getters to entity equals() and hashCode() comparison logic

### DIFF
--- a/src/main/java/com/laphayen/projectboard/domain/Article.java
+++ b/src/main/java/com/laphayen/projectboard/domain/Article.java
@@ -58,12 +58,12 @@ public class Article extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article that)) return false;
-        return id != null && id.equals(that.getId());
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 
 }

--- a/src/main/java/com/laphayen/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/laphayen/projectboard/domain/ArticleComment.java
@@ -48,12 +48,12 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.getId());
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 
 }

--- a/src/main/java/com/laphayen/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/laphayen/projectboard/domain/UserAccount.java
@@ -45,12 +45,12 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return userId != null && userId.equals(that.getUserId());
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 
 }


### PR DESCRIPTION
When accessing fields directly, it's not possible to perform comparison logic when dealing with proxy objects created by Hibernate for lazy loading, as the field values might be 'null'.
Using getters allows reading values correctly even when dealing with proxy objects.

This closes #69 