### PR TITLE
Migrate database from MySQL to PostgreSQL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.postgresql:postgresql'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,10 +9,9 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/board
+    url: jdbc:postgresql://localhost:5432/board
     username: laphayen
     password: qwer1234
-    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     open-in-view: false
     defer-datasource-initialization: true


### PR DESCRIPTION
Utilize the benefits of JPA to smoothly transition from MySQL to PostgreSQL.

This closes #73 