### PR TITLE
Enhancement of Comment Feature - First-level sub-comments: Update domain

### DIFF
--- a/src/main/java/com/laphayen/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/laphayen/projectboard/domain/ArticleComment.java
@@ -5,7 +5,9 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 @Getter
 @ToString(callSuper = true)
@@ -29,19 +31,34 @@ public class ArticleComment extends AuditingFields {
     @JoinColumn(name = "userId")
     @ManyToOne(optional = false)
     private UserAccount userAccount; // 유저 정보 (ID)
+
+    @Setter
+    @Column(updatable = false)
+    private Long parentCommentId; // 부모 댓글 ID
+
+    @ToString.Exclude
+    @OrderBy("createdAt ASC")
+    @OneToMany(mappedBy = "parentCommentId", cascade = CascadeType.ALL)
+    private Set<ArticleComment> childComments = new LinkedHashSet<>();
     
     @Setter @Column(nullable = false, length = 500) private String content; // 본문
 
     protected ArticleComment() {}
 
-    private ArticleComment(Article article, UserAccount userAccount, String content) {
+    private ArticleComment(Article article, UserAccount userAccount, Long parentCommentId, String content) {
         this.article = article;
         this.userAccount = userAccount;
+        this.parentCommentId = parentCommentId;
         this.content = content;
     }
 
     public static ArticleComment of(Article article, UserAccount userAccount, String content) {
-        return new ArticleComment(article, userAccount, content);
+        return new ArticleComment(article, userAccount, null, content);
+    }
+
+    public void addChildComment(ArticleComment child) {
+        child.setParentCommentId(this.getId());
+        this.getChildComments().add(child);
     }
 
     @Override


### PR DESCRIPTION
Add code to establish parent-child relationships within the child-comment domain.
Apply cascading rules to reflect changes in the child comments collection in the query.
Set up a unidirectional association by expressing the parent comment as a 'Long' id instead of an entity.
Add a method to allow the addition of child comments.

This closes #80 