### PR TITLE
AuditingFields: Modify field access modifiers to protected

### DIFF
--- a/src/main/java/com/laphayen/projectboard/domain/AuditingFields.java
+++ b/src/main/java/com/laphayen/projectboard/domain/AuditingFields.java
@@ -22,16 +22,16 @@ public abstract class AuditingFields{
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
-    @Column(nullable = false, updatable = false) private LocalDateTime createdAt; // 생성일시
+    @Column(nullable = false, updatable = false) protected LocalDateTime createdAt; // 생성일시
 
     @CreatedBy
-    @Column(nullable = false, updatable = false, length = 100) private String createdBy; // 생성자
+    @Column(nullable = false, updatable = false, length = 100) protected String createdBy; // 생성자
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
-    @Column(nullable = false) private LocalDateTime modifiedAt; // 수정일시
+    @Column(nullable = false) protected LocalDateTime modifiedAt; // 수정일시
 
     @LastModifiedBy
-    @Column(nullable = false, length = 100) private String modifiedBy; // 수정자
+    @Column(nullable = false, length = 100) protected String modifiedBy; // 수정자
 
 }


### PR DESCRIPTION
AuditingFields class is an abstract class, and each field should be accessible and modifiable by inheriting child entities. Therefore, the access modifiers should have been protected, but they were set too restrictively in the initial design.

Although this did not cause issues with the current business requirements, upcoming requirements for saving member information without authentication will necessitate the entity directly setting fields such as createdBy and modifiedBy. Therefore, the access modifiers should be adjusted to protected to meet these requirements.

This closes #92 